### PR TITLE
Tweak repo-digest:

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ Examples:
 Flags:
       --alsologtostderr    log to standard error as well as files
       --color              colorize standard error output according to severity (default "auto")
+      --inline-styles      Inline styles in generated html; good for standalone files (default true)
       --log-backtrace-at   when logging hits line file:N, emit a stack trace (default :0)
       --log-dir            if non-empty, write log files in this directory
       --logtostderr        log to standard error instead of files (default true)
+  -o, --outdir string      Output directory
   -r, --repo string        GitHub owner and repository, formatted as :owner/:repo
   -s, --since string       Fetch all opened and closed pull requests since this date (default "2016-02-07T19:00:00-05:00")
   -p, --template string    Go HTML template filename (see templates/ for examples)

--- a/digest.go
+++ b/digest.go
@@ -78,12 +78,16 @@ func Digest(c *Context, open, closed []*PullRequest) error {
 		return err
 	}
 
-	options := premailer.NewOptions()
-	options.CssToAttributes = true
-	prem := premailer.NewPremailerFromString(buf.String(), options)
-	html, err := prem.Transform()
-	if err != nil {
-		return err
+	contents := buf.String()
+
+	if c.InlineStyles {
+		options := premailer.NewOptions()
+		options.CssToAttributes = true
+		prem := premailer.NewPremailerFromString(buf.String(), options)
+		contents, err = prem.Transform()
+		if err != nil {
+			return err
+		}
 	}
 
 	f, err := createFile(c.OutDir, fmt.Sprintf("digest-%s.html", now.Format("01-02-2006")))
@@ -92,7 +96,7 @@ func Digest(c *Context, open, closed []*PullRequest) error {
 	}
 	defer f.Close()
 
-	_, err = f.WriteString(html)
+	_, err = f.WriteString(contents)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -65,6 +65,8 @@ const repoDesc = "GitHub owner and repository, formatted as :owner/:repo"
 
 const templateDesc = "Go HTML template filename (see templates/ for examples)"
 
+const outDirDesc = "Output directory"
+
 var digestCmd = &cobra.Command{
 	Use:   "repo-digest",
 	Short: "generate daily digests of repository activity",
@@ -104,6 +106,7 @@ type Context struct {
 	Token        string    // Access token
 	FetchSince   time.Time // Fetch all opened and closed PRs since this time
 	Template     string    // HTML template filename
+	OutDir       string    // Output directory
 	acceptHeader string    // Optional Accept: header value
 }
 
@@ -141,7 +144,7 @@ func runDigest(c *cobra.Command, args []string) error {
 	if len(open)+len(closed) == 0 {
 		latestTime = time.Now()
 	}
-	log.Infof("next digest should specify --since=%s", latestTime.Format(time.RFC3339))
+	fmt.Fprintf(os.Stdout, "nextsince: %s\n", latestTime.Format(time.RFC3339))
 	return nil
 }
 
@@ -161,6 +164,7 @@ func init() {
 	digestCmd.PersistentFlags().StringVarP(&since, "since", "s", defaultSince, fetchSinceDesc)
 	digestCmd.PersistentFlags().StringVarP(&ctx.Token, "token", "t", ctx.Token, accessTokenDesc)
 	digestCmd.PersistentFlags().StringVarP(&ctx.Template, "template", "p", ctx.Template, templateDesc)
+	digestCmd.PersistentFlags().StringVarP(&ctx.OutDir, "outdir", "o", ctx.OutDir, outDirDesc)
 
 	var err error
 	if ctx.FetchSince, err = time.Parse(time.RFC3339, since); err != nil {

--- a/main.go
+++ b/main.go
@@ -67,6 +67,8 @@ const templateDesc = "Go HTML template filename (see templates/ for examples)"
 
 const outDirDesc = "Output directory"
 
+const inlineStylesDesc = "Inline styles in generated html; good for standalone files"
+
 var digestCmd = &cobra.Command{
 	Use:   "repo-digest",
 	Short: "generate daily digests of repository activity",
@@ -107,6 +109,7 @@ type Context struct {
 	FetchSince   time.Time // Fetch all opened and closed PRs since this time
 	Template     string    // HTML template filename
 	OutDir       string    // Output directory
+	InlineStyles bool      // Inline style into generated html
 	acceptHeader string    // Optional Accept: header value
 }
 
@@ -165,6 +168,7 @@ func init() {
 	digestCmd.PersistentFlags().StringVarP(&ctx.Token, "token", "t", ctx.Token, accessTokenDesc)
 	digestCmd.PersistentFlags().StringVarP(&ctx.Template, "template", "p", ctx.Template, templateDesc)
 	digestCmd.PersistentFlags().StringVarP(&ctx.OutDir, "outdir", "o", ctx.OutDir, outDirDesc)
+	digestCmd.PersistentFlags().BoolVar(&ctx.InlineStyles, "inline-styles", true, inlineStylesDesc)
 
 	var err error
 	if ctx.FetchSince, err = time.Parse(time.RFC3339, since); err != nil {


### PR DESCRIPTION
- run generated html through premailer to inline css
- allows -o for output dir
- output nextsince and digest file to stdout (for easier parsing)
