### PR TITLE
Fix compile errors due to dependency drift

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -50,7 +50,7 @@ func markDowner(args ...interface{}) string {
 
 // Digest computes the digest from provided slices of open and
 // closed pull requests.
-func Digest(c *Context, open, closed []*PullRequest) error {
+func Digest(c *Config, open, closed []*PullRequest) error {
 	sortedOpen := PullRequests(open)
 	sortedClosed := PullRequests(closed)
 	sort.Sort(sortedOpen)

--- a/fetch.go
+++ b/fetch.go
@@ -97,7 +97,7 @@ func fetchURL(c *Config, url string, value interface{}) (string, error) {
 			time.Sleep(t.expiration())
 		case *httpError:
 			// For now, regard HTTP errors as permanent.
-			log.Printf("unable to fetch %q: %s\n", url, err)
+			log.Printf("unable to fetch %q: %v\n", url, t.resp)
 			return "", nil
 		default:
 			// Retry with exponential backoff on random connection and networking errors.

--- a/main.go
+++ b/main.go
@@ -19,12 +19,12 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"reflect"
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -143,12 +143,12 @@ func runDigest(c *cobra.Command, args []string) error {
 	}
 	cfg.FetchSince = cfg.FetchSince.Local()
 
-	log.Infof(ctx, "fetching GitHub data for repositor(ies) %s", cfg.Repos)
+	log.Printf("fetching GitHub data for repositor(ies) %s\n", cfg.Repos)
 	open, closed, err := Query(&cfg)
 	if err != nil {
 		return errors.Errorf("failed to query data: %s", err)
 	}
-	log.Infof(ctx, "creating digest for repositor(ies) %s", cfg.Repos)
+	log.Printf("creating digest for repositor(ies) %s\n", cfg.Repos)
 	if err := Digest(&cfg, open, closed); err != nil {
 		return errors.Errorf("failed to create digest: %s", err)
 	}

--- a/query.go
+++ b/query.go
@@ -18,13 +18,12 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"path"
 	"regexp"
 	"sort"
 	"strconv"
 	"time"
-
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // TODO(spencer): combine this code with the code in stargazers
@@ -288,13 +287,13 @@ func Query(c *Config) (open, closed []*PullRequest, err error) {
 // QueryPullRequests queries all pull requests from the repo or a
 // day's worth, whichever is greater.
 func QueryPullRequests(c *Config, repo string) ([]*PullRequest, []*PullRequest, error) {
-	log.Infof(ctx, "querying pull requests from %s opened or closed after %s", repo, c.FetchSince.Format(time.RFC3339))
+	log.Printf("querying pull requests from %s opened or closed after %s\n", repo, c.FetchSince.Format(time.RFC3339))
 	url := fmt.Sprintf("%srepos/%s/pulls?state=all&sort=updated&direction=desc", c.Host, repo)
 	open, closed := []*PullRequest{}, []*PullRequest{}
 	total := 0
 	var err error
 	var done bool
-	fmt.Printf("*** 0 open 0 closed, 0 total pull requests")
+	fmt.Println("*** 0 open 0 closed, 0 total pull requests")
 	for len(url) > 0 && !done {
 		fetched := []*PullRequest{}
 		url, err = fetchURL(c, url, &fetched)
@@ -335,7 +334,7 @@ func QueryPullRequests(c *Config, repo string) ([]*PullRequest, []*PullRequest, 
 					closed = append(closed, pr)
 				}
 			}
-			fmt.Printf("\r*** %s open %s closed %s total pull requests", format(len(open)), format(len(closed)), format(total))
+			fmt.Printf("\r*** %s open %s closed %s total pull requests\n", format(len(open)), format(len(closed)), format(total))
 		}
 	}
 	fmt.Printf("\n")
@@ -345,8 +344,8 @@ func QueryPullRequests(c *Config, repo string) ([]*PullRequest, []*PullRequest, 
 // QueryDetailedPullRequests queries detailed info on each pull request
 // in the provided slice.
 func QueryDetailedPullRequests(c *Config, prs []*PullRequest) error {
-	log.Infof(ctx, "querying detailed info for each of %s pull requests...", format(len(prs)))
-	fmt.Printf("*** detailed info for 0 pull requests")
+	log.Printf("querying detailed info for each of %s pull requests...\n", format(len(prs)))
+	fmt.Println("*** detailed info for 0 pull requests")
 	for i, pr := range prs {
 		// Fetch detailed pull request info.
 		if _, err := fetchURL(c, pr.URL, pr); err != nil {
@@ -364,7 +363,7 @@ func QueryDetailedPullRequests(c *Config, prs []*PullRequest) error {
 			}
 		}
 		pr.Files = newFiles
-		fmt.Printf("\r*** detailed info for %s pull requests", format(i+1))
+		fmt.Printf("\r*** detailed info for %s pull requests\n", format(i+1))
 	}
 	fmt.Printf("\n")
 	return nil

--- a/query.go
+++ b/query.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // TODO(spencer): combine this code with the code in stargazers
@@ -265,7 +265,7 @@ func (pr *PullRequest) ClosedAtStr() string {
 
 // Queries pull requests for the repository. Returns a slice each for
 // open and closed pull requests.
-func Query(c *Context) (open, closed []*PullRequest, err error) {
+func Query(c *Config) (open, closed []*PullRequest, err error) {
 	for _, repo := range c.Repos {
 		var os []*PullRequest
 		var cs []*PullRequest
@@ -287,8 +287,8 @@ func Query(c *Context) (open, closed []*PullRequest, err error) {
 
 // QueryPullRequests queries all pull requests from the repo or a
 // day's worth, whichever is greater.
-func QueryPullRequests(c *Context, repo string) ([]*PullRequest, []*PullRequest, error) {
-	log.Infof("querying pull requests from %s opened or closed after %s", repo, c.FetchSince.Format(time.RFC3339))
+func QueryPullRequests(c *Config, repo string) ([]*PullRequest, []*PullRequest, error) {
+	log.Infof(ctx, "querying pull requests from %s opened or closed after %s", repo, c.FetchSince.Format(time.RFC3339))
 	url := fmt.Sprintf("%srepos/%s/pulls?state=all&sort=updated&direction=desc", c.Host, repo)
 	open, closed := []*PullRequest{}, []*PullRequest{}
 	total := 0
@@ -344,8 +344,8 @@ func QueryPullRequests(c *Context, repo string) ([]*PullRequest, []*PullRequest,
 
 // QueryDetailedPullRequests queries detailed info on each pull request
 // in the provided slice.
-func QueryDetailedPullRequests(c *Context, prs []*PullRequest) error {
-	log.Infof("querying detailed info for each of %s pull requests...", format(len(prs)))
+func QueryDetailedPullRequests(c *Config, prs []*PullRequest) error {
+	log.Infof(ctx, "querying detailed info for each of %s pull requests...", format(len(prs)))
 	fmt.Printf("*** detailed info for 0 pull requests")
 	for i, pr := range prs {
 		// Fetch detailed pull request info.


### PR DESCRIPTION
The upstream cockroachdb/cockroach/util/log package now has an extra `pkg` path
component and its methods take a context.

Improve printing of HTTP errors, the old version was overly verbose.

Use Go standard logger. There was no added benefit to using our util package,
and keeping it would require dependency management.